### PR TITLE
Add ability to register custom services to Authom

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,39 @@ server.on("request", function(req, res) {
 server.listen(8000)
 ```
 
+### authom.registerService(serviceName, Service)
+
+Authom-compliant services can be registered using this method. This is useful for adding custom authentication services not suited to be part of the ```/lib``` core services. (For example a business-specific in-house authentication service.) _Custom services will override existing services of the same name._
+
+```javascript
+var authom = require("authom")
+  , EventEmitter = require("events").EventEmitter
+
+//Custom authentication service
+var IpAuth = function(options) {
+  var server = new EventEmitter
+  var whiteList = options.whiteList || ["127.0.0.1", "::1"]
+
+  server.on("request", function(req, res) {
+    if (~whiteList.indexOf(req.connection.remoteAddress)) {
+      server.emit("auth", req, res, {status: "yay"})
+    }
+    else {
+      server.emit("error", req, res, {status: "boo"})
+    }
+  })
+
+  return server
+}
+
+authom.registerService("ip-auth", IpAuth)
+
+auth.createServer({
+  service: "ip-auth",
+  whiteList : ["127.0.0.1", "::1", "192.168.0.1"]
+})
+```
+
 ### authom.route
 
 A regular expression that is run on the pathname of every request. authom will only run if this expression is matched. By default, it is `/^\/auth\/([^\/]+)\/?$/`.
@@ -231,6 +264,7 @@ A regular expression that is run on the pathname of every request. authom will o
 ### authom.app
 
 This is a convenience Express app, which should be mounted at a path containing a `:service` parameter.
+
 
 Providers
 ---------

--- a/lib/authom.js
+++ b/lib/authom.js
@@ -16,7 +16,7 @@ authom.createServer = function(options, listener) {
     , Service
     , server
 
-  if(!(Service = authom.customServices[name])){
+  if (!(Service = authom.customServices[name])) {
     try { Service = require(path) }
     catch (err) { throw "No such service: " + path }
   }
@@ -38,7 +38,7 @@ authom.createServer = function(options, listener) {
   return server  
 }
 
-authom.registerService = function(serviceName, Service){
+authom.registerService = function(serviceName, Service) {
   authom.customServices[serviceName] = Service
 }
 

--- a/lib/authom.js
+++ b/lib/authom.js
@@ -6,6 +6,7 @@ var fs = require("fs")
   , authom = module.exports = new EventEmitter
 
 authom.servers = {}
+authom.customServices = {}
 authom.route = /^\/auth\/([^\/]+)\/?$/
 
 authom.createServer = function(options, listener) {
@@ -15,8 +16,10 @@ authom.createServer = function(options, listener) {
     , Service
     , server
 
-  try { Service = require(path) }
-  catch (err) { throw "No such service: " + path }
+  if(!(Service = authom.customServices[name])){
+    try { Service = require(path) }
+    catch (err) { throw "No such service: " + path }
+  }
 
   server = authom.servers[name] = new Service(options)
 
@@ -33,6 +36,10 @@ authom.createServer = function(options, listener) {
   if (listener) server.on("request", listener)
 
   return server  
+}
+
+authom.registerService = function(serviceName, Service){
+  authom.customServices[serviceName] = Service
 }
 
 authom.listener = function(req, res) {


### PR DESCRIPTION
This pull adds the `registerService` method that allows someone to register an authom-compatible service that is too specific to go into the core services folder. (For example a business-specific login/pass system.)

This also allows to override the behavior of existing "core" services.

Also added documentation + usage example.
