### PR TITLE
set content type to help remote-side parsers (i.e. Connect.bodyParser)

### DIFF
--- a/lib/services/oauth2.js
+++ b/lib/services/oauth2.js
@@ -30,6 +30,7 @@ OAuth2.prototype.request = function(request, cb) {
     request.body = request.query.slice(1)
     request.headers || (request.headers = {})
     request.headers["Content-Length"] = Buffer.byteLength(request.body)
+    request.headers["Content-Type"] = 'application/x-www-form-urlencoded';
   }
 
   https


### PR DESCRIPTION
This was a missing piece for our custom provider implementation, which is implemented via Connect routes (having this header means not having to re-write/re-deploy body parsing code we already have in our request stack)
