### PR TITLE
Added mechanism for self-authenticated clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ github.on("auth", function(req, res, gitHubSpecificData){})
 github.on("error", function(req, res, gitHubSpecificData){})
 ```
 
-Or, use this to listen to events from all provders, since authom already listens and namespaces them for you:
+Or, use this to listen to events from all providers, since authom already listens and namespaces them for you:
 
 ```javascript
 authom.on("auth", function(req, res, data){})
@@ -229,11 +229,51 @@ server.listen(8000)
 
 ### authom.route
 
-A regular expression that is run on the pathname of every request. authom will only run if this expression is matched. By default, it is `/^\/auth\/([^\/]+)\/?$/`.
+A regular expression that is run on the pathname of every request. authom will only run if this expression is matched. By default, it is `/^\/auth\/([^\/][\w]+)\/?([\w]+)?.*?$/;`. It matches the second and third part of the path which are required to be matched for authom to function properly:
+
+* [0] The default match, the whole string if there's a match
+* [1] The second part of the path. This should contain the service used (e.g. 'facebook')
+* [2] The third part of the path. This should optionally contain the `verifyAuth` path (see [verifyAuth feature](#client-side-authentication-using-jssdk))
 
 ### authom.app
 
 This is a convenience Express app, which should be mounted at a path containing a `:service` parameter.
+
+## Client side authentication using JS/SDK
+
+Some providers (like Facebook) offer javascript SDKs that allow for a complete client side authentication. In those cases, the client performs all the authentication steps without the server ever getting touched.
+
+For such cases the `verifyAuth` mechanism is provided. After the client-side authentication completes, and the *Access Token* is available, we can perform a POST request to the server with the *Access Token* in order to:
+
+  1. Inform the server that we are authenticated with a provider
+  2. Have the server validate with the provider the authentication
+  3. Get back a proper response from the server with our auth logic (our local user data object)
+
+To enable the `verifyAuth` feature and configure it, the following API properties are available:
+
+### authom.verifyAuth
+
+A boolean parameter, which by default is set to `false`. Set it to `true` to enable the `verifyAuth` feature.
+
+### authom.verifyAuthPath
+
+A string indicating the path where the POST request should point to. By default it is set to `verifyAuth`. So if the provider is Facebook the full path would be:
+
+```
+/auth/facebook/verifyAuth
+```
+
+### authom.verifyAuthAccessTokenParam
+
+A string declaring the name of the *Access Token* parameter as passed from the POST request. By default it is named `accessToken`.
+
+### Additional setup for verifyAuth
+
+If you want to enable `verifyAuth` and you are using express, you need to add one additional line to your `app.js` file:
+
+```javascript
+app.post("/auth/:service/" + authom.verifyAuthPath, authom.app);
+```
 
 Providers
 ---------

--- a/lib/authom.js
+++ b/lib/authom.js
@@ -6,7 +6,53 @@ var fs = require("fs")
   , authom = module.exports = new EventEmitter
 
 authom.servers = {}
-authom.route = /^\/auth\/([^\/]+)\/?$/
+
+/**
+ * In case the external auth source supports client
+ * side authentication via a JS SDK/API (like Facebook),
+ * it is possible for the client to perform the authentication
+ * process all on its own.
+ *
+ * When that is done, all we have to do, server side, is get the
+ * Access Token and verify that this user may indeed authenticate
+ * with our services honoring his authentication with the third party
+ *
+ * This switch enables or disables this feature.
+ * By default it is disabled
+ *
+ * @type {boolean}
+ */
+authom.verifyAuth = false;
+/**
+ * The string (path) where we can perform an auth verification.
+ *
+ * This string will match on the third part of the path:
+ * e.g. /auth/facebook/verifyAuth
+ * or /auth/linkedin/verifyAuth
+ *
+ * The request to verifyAuth is performed via POST and
+ * an access token is expected to be passed
+ *
+ * @type {string}
+ */
+authom.verifyAuthPath = 'verifyAuth';
+/**
+ * In case of a verifyAuth operation, we expect the access token
+ * to be passed in the POST request that will be made. This variable
+ * defines the name of the parameter where we'll find the access token
+ *
+ * @type {string}
+ */
+authom.verifyAuthAccessTokenParam = 'accessToken';
+/**
+ * This regex will extract the second and third part
+ * of a path if it exists:
+ * [0] Whole sting, if there is a match
+ * [1] Second part of the path
+ * [2] Third part of the path
+ * @type {RegExp}
+ */
+authom.route = /^\/auth\/([^\/][\w]+)\/?([\w]+)?.*?$/
 
 authom.createServer = function(options, listener) {
   var service = options.service

--- a/lib/services/oauth2.js
+++ b/lib/services/oauth2.js
@@ -1,6 +1,7 @@
 var url = require("url")
   , https = require("https")
   , EventEmitter = require("events").EventEmitter
+  , authom = require('authom')
 
 function OAuth2(){}
 
@@ -52,7 +53,16 @@ OAuth2.prototype.request = function(request, cb) {
 OAuth2.prototype.onRequest = function(req, res) {
   var uri = req.url = this.parseURI(req)
 
-  if (uri.query.error) this.emit("error", req, res, uri.query)
+  // check for verify auth feature, and see if we have a path match
+  if(authom.verifyAuth) {
+    var match = uri.path.match(authom.route);
+    if (match && authom.verifyAuthPath === match[2]) {
+      this.onVerifyAuth(req, res, uri);
+      return;
+    }
+  }
+
+  if (uri.query.error) this.emit("error", req, res, uri.query);
 
   else if (uri.query.code) this.onCode(req, res)
 
@@ -77,23 +87,97 @@ OAuth2.prototype.onCode = function(req, res) {
   this.request(this.token, function(err, data) {
     if (err) return this.emit("error", req, res, err)
 
-    var tokenKey = this.user.tokenKey || "access_token"
+    // get the user data object from the auth source
+    // and emit auth or error events
+    this.getUserAndAuth(req, res, data.access_token);
 
-    this.user.query[tokenKey] = data.access_token
+  }.bind(this));
+};
 
-    this.request(this.user, function(err, user) {
-      if (err) return this.emit("error", req, res, err)
+/**
+ * Fetch the user data object from the authentication source
+ * and if this operation was successful emit the authentication
+ * event.
+ *
+ * We may optionally set a callback function.
+ *
+ * @param  {object} req The request object
+ * @param  {object} res The response object
+ * @param  {string} accessToken The access token to perform the operation
+ * @param  {Function(string?, object)=} opt_cb Optional callback
+ *                                      with the 'err' string as first param
+ *                                      and the 'user' object as second,
+ *                                      the callback is called before we
+ *                                      emit any events ('error' or 'auth').
+ * @return {void} nothing.
+ */
+OAuth2.prototype.getUserAndAuth = function(req, res, accessToken, opt_cb)
+{
+  var cb = opt_cb || function(){};
 
-      data = {
-        token: data.access_token,
-        id: this.getId(user),
-        data: user
-      }
+  var tokenKey = this.user.tokenKey || "access_token";
 
-      this.emit("auth", req, res, data)
-    }.bind(this))
-  }.bind(this))
-}
+  this.user.query[tokenKey] = accessToken;
+  this.request(this.user, function(err, user) {
+    if (err) {
+      cb(err).bind(this);
+      return this.emit("error", req, res, err);
+    }
+
+    var data = {
+      token: accessToken,
+      id: this.getId(user),
+      data: user
+    };
+
+    cb(err, user);
+    this.emit("auth", req, res, data);
+  }.bind(this));
+};
+
+
+/**
+ * Performs authentication verification with the external source.
+ *
+ * The authentication has already happened on the client side,
+ * we are just validating that this stands to truth by requesting
+ * the user object from the auth service using the Access Token
+ * provided by the client in this request.
+ *
+ * If we successfully get the auth token then the user is indeed
+ * authenticated and we emit the auth event.
+ *
+ * For security reasons we only allow this operation to be
+ * perfoed by a POST request
+ *
+ * @param  {object} req The request object
+ * @param  {object} res The response object
+ * @param  {object=} opt_uri Optionaly pass the uri object if already
+ *                           parsed, if not passed we parse again...
+ * @return {void} nothing.
+ */
+OAuth2.prototype.onVerifyAuth = function(req, res, opt_uri)
+{
+  var uri = opt_uri || this.parseURI(req);
+
+  // check if method is POST
+  if ('POST' !== req.method) {
+    this.emit('error', req, res, {message: 'Only POST is allowed for this action'});
+    return;
+  }
+  // get and validate the access token
+  var accessToken = req.param(authom.verifyAuthAccessTokenParam);
+  if ( 'string' === typeof accessToken && 0 < accessToken.length) {
+    // get the user data object from the auth source
+    // and emit auth or error events
+    this.getUserAndAuth(req, res, accessToken);
+    return;
+  }
+
+  // not a valid access token
+  this.emit('error', req, res, {message: 'The access token passed was not valid or was not set. Expected param name:' + authom.verifyAuthAccessTokenParam});
+
+};
 
 OAuth2.prototype.code = null
 OAuth2.prototype.token = null


### PR DESCRIPTION
Some providers (like Facebook) offer javascript SDKs that allow for a complete client side authentication. In those cases, the client performs all the authentication steps without the server ever getting touched.

For such cases the `verifyAuth` mechanism is provided. After the client-side authentication completes, and the _Access Token_ is available, we can perform a POST request to the server with the _Access Token_ in order to:
1. Inform the server that we are authenticated with a provider
2. Have the server validate with the provider the authentication
3. Get back a proper response from the server with our auth logic (our local user data object)

By default the `verifyAuth` mechanism is **turned off**.
