### PR TITLE
Fix #41 - custom Facebook fields are not correctly appended to the oauth request url.

### DIFF
--- a/lib/services/facebook.js
+++ b/lib/services/facebook.js
@@ -17,9 +17,8 @@ function Facebook(options) {
 
   this.user.query = {}
 
-  this.fields = ''
-  if (options.fields) {
-    this.fields = '?fields=' + options.fields.join(',')
+  if(options.fields) {
+    this.user.query.fields = options.fields.join( ',' )
   }
 
   this.on("request", this.onRequest.bind(this))
@@ -42,7 +41,7 @@ Facebook.prototype.token = {
 
 Facebook.prototype.user = {
   host: "graph.facebook.com",
-  path: "/me" + this.fields
+  path: "/me"
 }
 
 module.exports = Facebook


### PR DESCRIPTION
"this.fields" on line 44 of the facebook service always evaluate to "undefined", which would prompt facebook to poke into the page /meundefined instead of the proper `/me?fields=[bla]` url. (Would've also had hard-coded a query-string in the path on which a second one generated in oauth2.js would've been appended, which would've been problematic too.)

The following pull resolves the issue without removing the capability of adding custom fields by using the "this.user.query" object which was created for this purpose in the first place.
