### PR TITLE
Github API now requires User-Agent header

### DIFF
--- a/lib/services/oauth2.js
+++ b/lib/services/oauth2.js
@@ -29,13 +29,16 @@ OAuth2.prototype.request = function(original, cb) {
 
   if (request.method == "GET") {
     request.path += request.query
+    request.headers || (request.headers = {})
+    request.headers["User-Agent"] = 'authom/0.4';
   }
 
   else {
     request.body = request.query.slice(1)
     request.headers || (request.headers = {})
     request.headers["Content-Length"] = Buffer.byteLength(request.body)
-    request.headers["Content-Type"] = 'application/x-www-form-urlencoded';
+    request.headers["Content-Type"] = 'application/x-www-form-urlencoded'
+    request.headers["User-Agent"] = 'authom/0.4';
   }
 
   https


### PR DESCRIPTION
Github now requires that all api requests contain a User-Agent header (1).

This patch takes the easiest approach to achieve that. I'm sure that there is a cleaner, better integrated way, but this was the minimum viable solution for my app.

[1] http://developer.github.com/changes/2013-04-24-user-agent-required/
