### PR TITLE
fixing obvious sanity check - doh

### DIFF
--- a/lib/services/oauth2.js
+++ b/lib/services/oauth2.js
@@ -7,7 +7,7 @@ function OAuth2(options){
 
   // This option is necessary when the Oauth service has a self-signed cert.
   // Hopefully this is only set to false in the safety of testing but not out in the wild.
-  this.rejectUnauthorizedRequests = !(options.rejectUnauthorized == false);
+  this.rejectUnauthorizedRequests = !(options && options.rejectUnauthorized == false);
 
   EventEmitter.call(this);
 }


### PR DESCRIPTION
Missed an obvious sanity check for Issue #54. Sorry about that. These are the scenarios I have tested now.

var options; //true
//var options = null; // true
//var options = {}; // true
//var options = {rejectUnauthorized: true}; // true
//var options = {rejectUnauthorized: false}; // false
this.rejectUnauthorizedRequests = !(options && options.rejectUnauthorized == false);
console.log(this.rejectUnauthorizedRequests);
