### PR TITLE
Don't include .ico files in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+/lib/assets


### PR DESCRIPTION
Ignoring these files makes sense, since they are being served
through GitHub's CDN anyway. It seems like a micro optimization,
but considering the long list of dependencies some modules have,
it is generally speaking a good convention.

Alternative: Moving assets in separate gh-pages branch.
