### PR TITLE
prevent calling #emit() on a potentially undefined server var

### DIFF
--- a/lib/authom.js
+++ b/lib/authom.js
@@ -70,5 +70,7 @@ authom.app = function(req, res) {
   var name = req.params.service
     , server = authom.servers[name]
 
-  server.emit("request", req, res)
+  if (server) {
+    server.emit("request", req, res)
+  }
 }


### PR DESCRIPTION
Hi,

Very small 'fix' to prevent calling emit on an undefined server.

best,
Stefan
