### PR TITLE
More indicative example for google

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ var google = authom.createServer({
   service: "google",
   id: "515913292583.apps.googleusercontent.com",
   secret: "UAjUGd_MD9Bkho-kazmJ5Icm",
-  scope: ""
+  scope: ["https://www.googleapis.com/auth/userinfo.email"] 
 })
 ```
 


### PR DESCRIPTION
Currently the only way to figure out google scope needs an array is to read the code. This minor change in README.md would make it more evident.
